### PR TITLE
monitor BOPs in array

### DIFF
--- a/sol/BurnableOpenPayment.sol
+++ b/sol/BurnableOpenPayment.sol
@@ -15,49 +15,80 @@
 
 pragma solidity ^0.4.10;
 
+contract BurnableOpenPaymentFactory {
+    event NewBOP(address newBOPAddress, address payer, uint commitThreshold, BurnableOpenPayment.DefaultAction defaultAction, uint defaultTimeoutLength, string initialPayerString);
+
+    //contract address array
+    address[] public contracts;
+
+    function getContractCount()
+    public
+    constant
+    returns(uint)
+    {
+      return contracts.length;
+    }
+
+
+    function newBurnableOpenPayment(address payer, uint commitThreshold, BurnableOpenPayment.DefaultAction defaultAction, uint defaultTimeoutLength, string initialPayerString)
+    public
+    payable
+    returns (address) {
+        //pass along any ether to the constructor
+        address newBOPAddr = (new BurnableOpenPayment).value(msg.value)(payer, commitThreshold, defaultAction, defaultTimeoutLength, initialPayerString);
+        NewBOP(newBOPAddr, payer, commitThreshold, defaultAction, defaultTimeoutLength, initialPayerString);
+
+        //save created BOPs in contract array
+        contracts.push(newBOPAddr);
+
+        return newBOPAddr;
+    }
+}
+
+
 contract BurnableOpenPayment {
     //BOP will start with a payer but no recipient (recipient==0x0)
     address public payer;
     address public recipient;
     address constant burnAddress = 0x0;
-    
+
     //Note that these will track, but not influence the BOP logic.
     uint public amountDeposited;
     uint public amountBurned;
     uint public amountReleased;
-    
+
     //payerString and recipientString enable rudimentary communication/publishing.
     //Although the two parties might quickly move to another medium with better privacy or convenience,
     //beginning with this is nice because it's already trustless/transparent/signed/pseudonymous/etc.
     string public payerString;
     string public recipientString;
-    
+
     //Amount of ether a prospective recipient must pay to permanently become the recipient. See commit().
     uint public commitThreshold;
-    
+
     //What if the payer falls off the face of the planet?
     //A BOP is instantiated with a chosen defaultAction, which cannot be changed after instantiation.
     enum DefaultAction {None, Release, Burn}
     DefaultAction public defaultAction;
-    
+
     //if defaultAction != None, how long should we wait allowing the default action to be called?
     uint public defaultTimeoutLength;
-    
+
     //Calculated from defaultTimeoutLength in commit(),
     //and recaluclated whenever the payer (or possibly the recipient) calls delayDefaultAction()
     uint public defaultTriggerTime;
-    
+
     //Most action happens in the Committed state.
     enum State {Open, Committed, Expended}
     State public state;
     //Note that a BOP cannot go from Committed back to Open, but it can go from Expended back to Committed
     //(this would retain the committed recipient). Search for Expended and Unexpended events to see how this works.
-    
+
     modifier inState(State s) { require(s == state); _; }
     modifier onlyPayer() { require(msg.sender == payer); _; }
     modifier onlyRecipient() { require(msg.sender == recipient); _; }
     modifier onlyPayerOrRecipient() { require((msg.sender == payer) || (msg.sender == recipient)); _; }
-    
+
     event Created(address payer, uint commitThreshold, BurnableOpenPayment.DefaultAction defaultAction, uint defaultTimeoutLength, string initialPayerString);
     event FundsAdded(uint amount);//The payer has added funds to the BOP.
     event PayerStringUpdated(string newPayerString);
@@ -70,42 +101,42 @@ contract BurnableOpenPayment {
     event Unexpended();
     event DefaultActionDelayed();
     event DefaultActionCalled();
-    
+
     function BurnableOpenPayment(address _payer, uint _commitThreshold, DefaultAction _defaultAction, uint _defaultTimeoutLength, string _payerString)
     public
     payable {
         Created(_payer, _commitThreshold, _defaultAction, _defaultTimeoutLength, _payerString);
-        
+
         if (msg.value > 0) {
             FundsAdded(msg.value);
             amountDeposited += msg.value;
         }
-            
+
         state = State.Open;
         payer = _payer;
-        
+
         commitThreshold = _commitThreshold;
-        
+
         defaultAction = _defaultAction;
-        if (defaultAction != DefaultAction.None) 
+        if (defaultAction != DefaultAction.None)
             defaultTimeoutLength = _defaultTimeoutLength;
-        
+
         payerString = _payerString;
     }
-    
+
     function getFullState()
     public
     constant
     returns (State, address, string, address, string, uint, uint, uint, uint, uint, DefaultAction, uint, uint) {
         return (state, payer, payerString, recipient, recipientString, this.balance, commitThreshold, amountDeposited, amountBurned, amountReleased, defaultAction, defaultTimeoutLength, defaultTriggerTime);
     }
-    
+
     function addFunds()
     public
     onlyPayer()
     payable {
         require(msg.value > 0);
-        
+
         FundsAdded(msg.value);
         amountDeposited += msg.value;
         if (state == State.Expended) {
@@ -113,7 +144,7 @@ contract BurnableOpenPayment {
             Unexpended();
         }
     }
-    
+
     function recoverFunds()
     public
     onlyPayer()
@@ -122,43 +153,43 @@ contract BurnableOpenPayment {
         FundsRecovered();
         selfdestruct(payer);
     }
-    
+
     function commit()
     public
     inState(State.Open)
     payable
     {
         require(msg.value >= commitThreshold);
-        
+
         if (msg.value > 0) {
             FundsAdded(msg.value);
             amountDeposited += msg.value;
         }
-        
+
         recipient = msg.sender;
         state = State.Committed;
         Committed(recipient);
-        
+
         if (defaultAction != DefaultAction.None) {
             defaultTriggerTime = now + defaultTimeoutLength;
         }
     }
-    
+
     function internalBurn(uint amount)
     private
     inState(State.Committed)
     {
         burnAddress.transfer(amount);
-        
+
         amountBurned += amount;
         FundsBurned(amount);
-        
+
         if (this.balance == 0) {
             state = State.Expended;
             Expended();
         }
     }
-    
+
     function burn(uint amount)
     public
     inState(State.Committed)
@@ -166,22 +197,22 @@ contract BurnableOpenPayment {
     {
         internalBurn(amount);
     }
-    
+
     function internalRelease(uint amount)
     private
     inState(State.Committed)
     {
         recipient.transfer(amount);
-        
+
         amountReleased += amount;
         FundsReleased(amount);
-        
+
         if (this.balance == 0) {
             state = State.Expended;
             Expended();
         }
     }
-    
+
     function release(uint amount)
     public
     inState(State.Committed)
@@ -189,7 +220,7 @@ contract BurnableOpenPayment {
     {
         internalRelease(amount);
     }
-    
+
     function setPayerString(string _string)
     public
     onlyPayer()
@@ -197,7 +228,7 @@ contract BurnableOpenPayment {
         payerString = _string;
         PayerStringUpdated(payerString);
     }
-    
+
     function setRecipientString(string _string)
     public
     onlyRecipient()
@@ -205,18 +236,18 @@ contract BurnableOpenPayment {
         recipientString = _string;
         RecipientStringUpdated(recipientString);
     }
-    
+
     function delayDefaultAction()
     public
     onlyPayerOrRecipient()
     inState(State.Committed)
     {
         require(defaultAction != DefaultAction.None);
-        
+
         defaultTriggerTime = now + defaultTimeoutLength;
         DefaultActionDelayed();
     }
-    
+
     function callDefaultAction()
     public
     onlyPayerOrRecipient()
@@ -224,7 +255,7 @@ contract BurnableOpenPayment {
     {
         require(defaultAction != DefaultAction.None);
         require(now >= defaultTriggerTime);
-        
+
         if (defaultAction == DefaultAction.Burn) {
             internalBurn(this.balance);
         }
@@ -232,19 +263,5 @@ contract BurnableOpenPayment {
             internalRelease(this.balance);
         }
         DefaultActionCalled();
-    }
-}
-
-contract BurnableOpenPaymentFactory {
-    event NewBOP(address newBOPAddress, address payer, uint commitThreshold, BurnableOpenPayment.DefaultAction defaultAction, uint defaultTimeoutLength, string initialPayerString);
-    
-    function newBurnableOpenPayment(address payer, uint commitThreshold, BurnableOpenPayment.DefaultAction defaultAction, uint defaultTimeoutLength, string initialPayerString)
-    public
-    payable
-    returns (address) {
-        //pass along any ether to the constructor
-        address newBOPAddr = (new BurnableOpenPayment).value(msg.value)(payer, commitThreshold, defaultAction, defaultTimeoutLength, initialPayerString);
-        NewBOP(newBOPAddr, payer, commitThreshold, defaultAction, defaultTimeoutLength, initialPayerString);
-        return newBOPAddr;
     }
 }


### PR DESCRIPTION
I added an array of addresses, to be filled with created BOP addresses, and a function to push the newly created address to the array. The idea is, that n calls (with n standing for the number of created BOPs) to the contract will be sufficient to get the current BOP addresses, instead of checking events in all blocks since contract creation, which is slow and will take more and more time, as more blocks are needed to be checked on an event.. Will test now, let me know your thoughts.
